### PR TITLE
Singly Linked List bug fix

### DIFF
--- a/src/components/Node/LinkedListContainer.tsx
+++ b/src/components/Node/LinkedListContainer.tsx
@@ -13,7 +13,7 @@ interface Props {
 const LinkedListContainer = ({ node, index, insertAt, listSize, type}: Props) => {
   return (
     <motion.div
-      key={`${node.value}+${index}+${type}`}
+      key={node.id}
       className={`flex flex-row relative h-[60px] cursor-pointer ${node.lastAdded ? 'border-2 border-red-400' : ''}`}
       initial={{ opacity: 0, translateX: -200}}
       animate={{ opacity: 1, translateX: 0}}

--- a/src/components/Node/Node.ts
+++ b/src/components/Node/Node.ts
@@ -3,13 +3,15 @@ export interface NodeObject {
   lastAdded: boolean;
   next?: NodeObject | null;
   prev?: NodeObject | null;
+  id: number;
 }
 
 
-export const Node = (value: string | number, next?: NodeObject | null, prev?: NodeObject | null) => {
+export const Node = (value: string | number, id: number, next?: NodeObject | null, prev?: NodeObject | null) => {
   const node:NodeObject = {
     value: value,
     lastAdded: true,
+    id: id,
   }
   if (next) {
     node.next = next;

--- a/src/components/Node/NodeContainer.tsx
+++ b/src/components/Node/NodeContainer.tsx
@@ -22,7 +22,7 @@ const NodeContainer = ({ node, index, type }:Props) => {
 
   return (
       <motion.div
-        key={`${node} + ${index}`}
+        key={node.id}
         className={`w-[150px] h-[40px] flex justify-center items-center relative ${node.lastAdded ? 'border-2 border-red-400' : ' border border-black'}`}
         variants={type === 'stack' ? Stacks : Queue}
         initial="enter"

--- a/src/pages/SinglyLinkedList.tsx
+++ b/src/pages/SinglyLinkedList.tsx
@@ -13,6 +13,7 @@ const SinglyLinkedList = () => {
   const [removed, setRemoved] = useState<NodeObject | null>(null);
   const [insert, setInsert] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [newID, setNewID] = useState(1);
 
   const setRemovedNode = (node: NodeObject) => {
     setRemoved(node);
@@ -30,7 +31,8 @@ const SinglyLinkedList = () => {
   const addToTail = useCallback(() => {
     const value = inputRef.current!.value;
     if (value === '') return;
-    const newNode = Node(value, null);
+    const newNode = Node(value, newID, null);
+    setNewID(newID + 1);
     if (linkedList.length > 0) {
       addNew();
       const lastNode = linkedList[linkedList.length - 1];
@@ -60,7 +62,8 @@ const SinglyLinkedList = () => {
     const value = inputRef.current!.value;
     if (value === '') return;
     const currentFirstNode = linkedList.length > 0 ? linkedList[0] : null;
-    const newNode = Node(value, currentFirstNode);
+    const newNode = Node(value, newID, currentFirstNode);
+    setNewID(newID + 1);
     addNew();
     setLinkedList([newNode, ...linkedList]);
     inputRef.current!.value = '';
@@ -85,7 +88,8 @@ const SinglyLinkedList = () => {
     addNew();
     const currentNode = linkedList[index];
     const nextNode = currentNode.next;
-    const newNode = Node(value, nextNode);
+    const newNode = Node(value, newID, nextNode);
+    setNewID(newID + 1);
     currentNode.next = newNode;
     const newList = [];
     let firstNode = linkedList[0];
@@ -114,7 +118,7 @@ const SinglyLinkedList = () => {
         {
           linkedList.map((node, index) => {
             return (
-              <Fragment key={index}>
+              <Fragment key={node.id}>
                 <LinkedListContainer node={node} index={index} insertAt={insertAt} listSize={listSize} type="singly"/>
               </Fragment>
             )


### PR DESCRIPTION
Added a simple incremented unique id for any new nodes and node related components. It seems to have fixed the re-render issue for Singly Linked List. The same concept could be applied to doubly linked lists, either the same way, as a state at the top of the component, or having a universal unique ID generator pulled out into a memo or context to be used across all data types/files. 

Cool project!

